### PR TITLE
Add Meah Berachos privacy policy page

### DIFF
--- a/public/meah-berachos-privacy.html
+++ b/public/meah-berachos-privacy.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Privacy Policy · Meah Berachos</title>
+<meta name="robots" content="index,follow">
+<meta name="description" content="Privacy policy for the Meah Berachos iOS app.">
+<style>
+  :root { --ink:#1c2230; --muted:#5b6473; --line:#e6e3da; --accent:#b07d2b; --bg:#faf7f0; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--ink);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    line-height: 1.65; -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 720px; margin: 0 auto; padding: 48px 20px 80px; }
+  .home { display: inline-block; margin-bottom: 24px; color: var(--accent); text-decoration: none; font-size: .9rem; }
+  .home:hover { text-decoration: underline; }
+  h1 { font-size: 1.8rem; margin: 0 0 4px; letter-spacing: .2px; }
+  .updated { color: var(--muted); font-size: .9rem; margin-bottom: 28px; }
+  h2 { font-size: 1.15rem; margin: 34px 0 8px; }
+  p, li { color: #2a3140; }
+  a { color: var(--accent); }
+  ul { padding-left: 1.2em; }
+  li { margin: 4px 0; }
+  .lead {
+    background: #fff; border: 1px solid var(--line); border-radius: 12px;
+    padding: 16px 18px; margin: 8px 0 8px;
+  }
+  hr { border: 0; border-top: 1px solid var(--line); margin: 36px 0; }
+  footer { color: var(--muted); font-size: .85rem; margin-top: 40px; }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <a class="home" href="/">← korbancalculator.com</a>
+    <h1>Privacy Policy — Meah Berachos</h1>
+    <div class="updated">Last updated: May 31, 2026</div>
+
+    <p>Meah Berachos (“the App”) is built by Morris Massel
+       (<a href="https://www.korbancalculator.com">korbancalculator.com</a>). This policy explains
+       what the App does — and does not — collect.</p>
+
+    <div class="lead">
+      <strong>The short version:</strong> The App has no accounts and no login. Your berachos counts
+      and settings are stored on your device. We do not sell your data, show ads, or use third-party
+      analytics or tracking.
+    </div>
+
+    <h2>What’s stored on your device</h2>
+    <ul>
+      <li>Your daily counts, streak, nusach, and preferences are saved locally on your device.</li>
+      <li>If you enable iCloud, this information is also backed up to your own private iCloud account
+          (via Apple’s iCloud key-value storage) so it syncs across your devices. That data is
+          controlled by your Apple ID; we have no access to it.</li>
+    </ul>
+
+    <h2>Location</h2>
+    <ul>
+      <li>If you allow location access, your approximate location is used to calculate the halachic
+          day boundary (tzeis) and zmanim.</li>
+      <li>To show zmanim and candle-lighting / Havdalah times, your coordinates are sent to the Hebcal
+          API (hebcal.com), which returns times for your location. Location is used only for this
+          purpose, is not stored by us, and is not linked to your identity.</li>
+      <li>You can use the App without granting location; some time-based features will be limited.</li>
+    </ul>
+
+    <h2>Community count</h2>
+    <p>The App shows an optional shared “community tally.” When you add berachos, the App may send an
+       anonymous increment — just a number — to our counter service. It contains no name, email,
+       location, nusach, or personal history; only the count being added.</p>
+
+    <h2>Third-party services</h2>
+    <p>The App connects to these services to provide content. It does not share personal information
+       with them beyond what is noted:</p>
+    <ul>
+      <li><strong>Hebcal</strong> (hebcal.com) — zmanim and Daf Yomi; receives approximate location
+          only for zmanim.</li>
+      <li><strong>Sefaria</strong> (sefaria.org) — liturgical text; no personal data.</li>
+      <li><strong>Cloudflare</strong> — hosts the anonymous community-count service.</li>
+      <li><strong>Apple</strong> — iCloud backup (your account) and App Store distribution.</li>
+    </ul>
+
+    <h2>Notifications</h2>
+    <p>If you enable reminders, the App schedules local notifications on your device. No notification
+       data is sent to us.</p>
+
+    <h2>Children’s privacy</h2>
+    <p>The App does not knowingly collect personal information from anyone, including children.</p>
+
+    <h2>Data deletion</h2>
+    <p>Because there are no accounts, there is no server-side personal data to delete. To remove local
+       data, use the App’s “Reset All Data” option or delete the App. iCloud data is managed in your
+       device’s iCloud settings.</p>
+
+    <h2>Changes</h2>
+    <p>We may update this policy from time to time; the “Last updated” date above will change
+       accordingly.</p>
+
+    <hr>
+    <h2>Contact</h2>
+    <p>Questions about this policy: <a href="mailto:info@korbancalculator.com">info@korbancalculator.com</a></p>
+
+    <footer>Meah Berachos · לזכות רפואה שלימה — חוה מרים בת מלכה פריידא</footer>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Adds a static privacy policy page at `/meah-berachos-privacy.html` (served from `public/`) for the Meah Berachos iOS app's App Store "Privacy Policy URL".

Standalone HTML, no SPA dependency, no analytics. Once merged + deployed, it's live at https://www.korbancalculator.com/meah-berachos-privacy.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)